### PR TITLE
Add support for testing Lucee 4.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ env:
     - PLATFORM=railo40 TESTFRAMEWORK=mxunit
     - PLATFORM=railo41 TESTFRAMEWORK=mxunit
     - PLATFORM=railo42 TESTFRAMEWORK=mxunit
+    - PLATFORM=lucee451 TESTFRAMEWORK=mxunit
     - PLATFORM=acf10-linux64 TESTFRAMEWORK=mxunit
     - PLATFORM=acf902-linux64 TESTFRAMEWORK=mxunit
     - PLATFORM=railo40 TESTFRAMEWORK=testbox
     - PLATFORM=railo41 TESTFRAMEWORK=testbox
     - PLATFORM=railo42 TESTFRAMEWORK=testbox
+    - PLATFORM=lucee451 TESTFRAMEWORK=testbox
     - PLATFORM=acf10-linux64 TESTFRAMEWORK=testbox
 
 install: ant -Dtest.framework=$TESTFRAMEWORK -Dsource=remote -Dwork.dir=$HOME/work -Dbuild.dir=$TRAVIS_BUILD_DIR -Dplatform=$PLATFORM install-ci-deps

--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,7 @@
   <property name="railo41.local.url" value="/opt/ci/railo-express-4.1.2.005-nojre.tar.gz" />
   <property name="railo42.local.url" value="/opt/ci/railo-express-4.2.1.000-nojre.tar.gz" />
   <property name="railo41-osx.local.url" value="/opt/ci/railo-express-4.1.2.005-macosx.zip" />
+  <property name="lucee451.local.url" value="/opt/ci/lucee-express-4.5.1.000.zip" />
   <property name="acf10-linux32.local.url" value="/opt/ci/cf10-linux32.tar.gz" />
   <property name="acf10-linux64.local.url" value="/opt/ci/cf10-linux64.tar.gz" />
   <property name="acf902-linux64.local.url" value="/opt/ci/cf902-linux64.tar.gz" />
@@ -45,6 +46,7 @@
   <property name="railo40.remote.url" value="http://cfml-ci.s3.amazonaws.com/railo-express-4.0.4.001-nojre.tar.gz" />
   <property name="railo41.remote.url" value="http://cfml-ci.s3.amazonaws.com/railo-express-4.1.2.005-nojre.tar.gz" />
   <property name="railo42.remote.url" value="http://cfml-ci.s3.amazonaws.com/railo-express-4.2.1.000-nojre.tar.gz" />
+  <property name="lucee451.remote.url" value="https://bitbucket.org/lucee/lucee/downloads/lucee-4.5.1.000-express.zip" />
   <property name="acf10-linux32.remote.url" value="http://cfml-ci.s3.amazonaws.com/cf10-linux32.tar.gz" />
   <property name="acf10-linux64.remote.url" value="http://cfml-ci.s3.amazonaws.com/cf10-linux64.tar.gz" />
   <property name="acf902-linux64.remote.url" value="http://cfml-ci.s3.amazonaws.com/cf902-linux64.tar.gz" />
@@ -64,6 +66,7 @@
   <property name="railo41.helper" value="railo" />
   <property name="railo41-osx.helper" value="railo" />
   <property name="railo42.helper" value="railo-42plus" />
+  <property name="lucee451.helper" value="lucee" />
   <property name="acf10-linux32.helper" value="acf" />
   <property name="acf10-linux64.helper" value="acf" />
   <property name="acf902-linux64.helper" value="acf9" />

--- a/tests/ci/scripts/ci-helper-lucee.sh
+++ b/tests/ci/scripts/ci-helper-lucee.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+case $1 in
+    start)
+        CONTROL_SCRIPT='./startup.sh'
+        ;;
+    stop)
+        CONTROL_SCRIPT='./shutdown.sh'
+        ;;
+esac
+
+PLATFORM_DIR="lucee"
+WEBROOT="webapps/ROOT"
+MY_DIR=`dirname $0`
+source $MY_DIR/ci-helper-base.sh $1 $2
+
+case $1 in
+    install)
+        chmod a+x ./startup.sh
+        chmod a+x ./shutdown.sh
+        ;;
+    start|stop)
+        ;;
+    *)
+        echo "Usage: $0 {install|start|stop}"
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Reference: https://github.com/marcins/cfml-ci/issues/18

This pull request adds support for using Continuous Integration (specifically with TravisCI) with Lucee 4.5.1.

The Lucee instance used is the express server located at https://bitbucket.org/lucee/lucee/downloads/lucee-4.5.1.000-express.zip.